### PR TITLE
Fix citation link in citation_funding.html

### DIFF
--- a/citation_funding.html
+++ b/citation_funding.html
@@ -12,7 +12,7 @@
     McGuffie,M.J. and Barrick,J.E. (2021) pLannotate: 
     engineered plasmid annotation. <i>Nucleic Acids Research</i> 
     <br>
-    <b>DOI</b>: <a href="10.1093/nar/gkab374">10.1093/nar/gkab374</a>
+    <b>DOI</b>: <a href="https://doi.org/10.1093/nar/gkab374">10.1093/nar/gkab374</a>
     <br>
     <br>
     pLannotate development was supported by the National Science 


### PR DESCRIPTION
Paper's DOI href lacked a resolver FQDN, leading to instance-relative path behavior ⇒ 404.