### PR TITLE
Infernal output could align to the negative strand

### DIFF
--- a/plannotate/infernal.py
+++ b/plannotate/infernal.py
@@ -43,6 +43,8 @@ def parse_infernal(file_loc):
     infernal = infernal.apply(pd.to_numeric, errors='ignore', downcast = "integer")
     
     infernal['qseq'] = ""
+    to_swap = infernal['qend'] < infernal['qstart']
+    infernal.loc[to_swap, ['qstart', 'qend']] = infernal.loc[to_swap, ['qend', 'qstart']].values
     infernal["sframe"] = infernal["sframe"].replace(["-","+"], [-1,1])
     infernal['qstart'] = infernal['qstart']-1
     infernal['qend']   = infernal['qend']-1

--- a/plannotate/infernal.py
+++ b/plannotate/infernal.py
@@ -45,6 +45,7 @@ def parse_infernal(file_loc):
     infernal['qseq'] = ""
     to_swap = infernal['qend'] < infernal['qstart']
     infernal.loc[to_swap, ['qstart', 'qend']] = infernal.loc[to_swap, ['qend', 'qstart']].values
+    infernal[['qstart', 'qend']] = infernal[['qstart', 'qend']].apply(pd.to_numeric, downcast='integer')
     infernal["sframe"] = infernal["sframe"].replace(["-","+"], [-1,1])
     infernal['qstart'] = infernal['qstart']-1
     infernal['qend']   = infernal['qend']-1


### PR DESCRIPTION
This makes sure we don't get empty values here: https://github.com/barricklab/pLannotate/blob/daabf1a63be79c43ff6166c76403d358b1d53da8/plannotate/annotate.py#L385